### PR TITLE
Conflict with `laminas-servicemanager` <3.11 and move to `PSR-11` interface

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches:
+      - '[0-9]+.[0-9]+.x'
+      - 'refs/pull/*'
     tags:
 
 jobs:

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
     "psalm/plugin-phpunit": "^0.17.0",
     "vimeo/psalm": "^4.10"
   },
+  "conflict": {
+    "laminas/laminas-servicemanager": "<3.11"
+  },
   "config": {
     "sort-packages": true,
     "platform": {

--- a/src/Session/AdapterPluginManagerDelegatorFactory.php
+++ b/src/Session/AdapterPluginManagerDelegatorFactory.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Laminas\Cache\Storage\Adapter\Session;
 
-use interop\container\containerinterface;
 use Laminas\Cache\Storage\Adapter\Session;
 use Laminas\Cache\Storage\AdapterPluginManager;
 use Laminas\ServiceManager\Factory\InvokableFactory;
+use Psr\Container\ContainerInterface;
 
 use function assert;
 
 final class AdapterPluginManagerDelegatorFactory
 {
-    public function __invoke(containerinterface $container, string $name, callable $callback): AdapterPluginManager
+    public function __invoke(ContainerInterface $container, string $name, callable $callback): AdapterPluginManager
     {
         $pluginManager = $callback();
         assert($pluginManager instanceof AdapterPluginManager);


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

In #19, the codestandard was updated and therefore the `container-interop` interface was renamed.
To get rid of that interface at all, we have to conflict with `laminas-servicemanager` versions lower than 3.11 to ensure that we have a replacement for that interface.
